### PR TITLE
Help build to complete with ../libstb present

### DIFF
--- a/HCA/Makefile
+++ b/HCA/Makefile
@@ -6,7 +6,7 @@
 ###########################################
 #     installed location of where to find libstb
 #       i.e.,   libstb.a is in $(STB)/lib/
-STB_HOME := /home/wbuntine
+STB_HOME := $(shell pwd)/../../libstb
 export STB_HOME
 
 #######################################
@@ -18,19 +18,23 @@ export STB_HOME
 # MYDEBUG=-pg -DNDEBUG -ffast-math -DHAVE_INLINE # -DH_THREADS
 # MYDEBUG=-O5 -DNDEBUG -ffast-math -DHAVE_INLINE -DH_THREADS
 MYDEBUG=-g
-MYLIB=-g
-CPPFLAGS =  -I../util/ -I$(STB_HOME)/include/ $(MYDEBUG)
-CFLAGS = -Wall 
-LDFLAGS = -L../util -L$(STB_HOME)/lib -lhca -lstb$(MYLIB)  -lm -pthread
+CPPFLAGS :=  -I$(shell pwd)/util/ -I$(STB_HOME)/lib/ $(MYDEBUG)
+CFLAGS = -Wall
+LDFLAGS := -L$(shell pwd)/util -L$(STB_HOME)/lib
+LIBS = -lhca -lstb -lm -pthread
+
+CC = gcc
 
 ####################################################
 ##  Mac OSX versions
 #CFLAGS = -D__WORDSIZE=64 -I/opt/local/include -Wall
 #LDFLAGS = -L/opt/local/lib -L../util -L../lib -lhca -lstb -lm -pthread
-#CPPFLAGS=-I/opt/local/include -I../util/ -I../lib/ 
+#CPPFLAGS=-I/opt/local/include -I../util/ -I../lib/
 
+export CC
 export CFLAGS
 export LDFLAGS
+export LIBS
 export CPPFLAGS
 
 all:    util hca tca
@@ -38,32 +42,32 @@ all:    util hca tca
 yes:
 
 util:    yes
-	cd util; make 
+	cd util; ${MAKE}
 
 terms:    yes
-	cd util; make terms
+	cd util; ${MAKE} terms
 
 heap:    yes
-	cd util; make heap
+	cd util; ${MAKE} heap
 
 hca:    yes
 
 hca:    yes
-	cd hca; make 
+	cd hca; ${MAKE}
 
 tca:    yes
-	cd tca; make 
+	cd tca; ${MAKE}
 
 clean:  yes
-	cd util; make clean
-	cd hca; make clean	
-	cd tca; make clean	
+	cd util; ${MAKE} clean
+	cd hca; ${MAKE} clean
+	cd tca; ${MAKE} clean
 
-distclean: 
+distclean:
 	rm -f TAGS */TAGS
-	cd util; make distclean
-	cd hca; make distclean	
-	cd tca; make distclean	
+	cd util; ${MAKE} distclean
+	cd hca; ${MAKE} distclean
+	cd tca; ${MAKE} distclean
 
-etags:  
+etags:
 	etags  util/*.c util/*.h dca/*.h cca/*.h

--- a/HCA/README
+++ b/HCA/README
@@ -42,8 +42,9 @@ the OSX doesn't support it the same.
 MAKING the PROGRAMME
 ====================
 
-The only prerequisite is libstb.  Although in Windows you will need to
-compile with "gcc", and in OSX "gcc" is best supported.
+The only prerequisite is libstb.  By default, it is expected to be
+found in the same directory where topic-models is found.  In Windows
+you will need to compile with "gcc", and in OSX "gcc" is best supported.
 
 There is a simple Makefile in this directory currently configured to
 optimise the compiler for a Linux machine.  Edit the configuration if

--- a/HCA/README
+++ b/HCA/README
@@ -41,11 +41,13 @@ the OSX doesn't support it the same.
 
 MAKING the PROGRAMME
 ====================
-There are no prerequisites.  Although in Windows you will
-need to compile with "gcc" and in OSX "gcc" is best supported.
-There is a simple Makefile in this directory currently configured
-to optimise the compiler for a Linux machine.  Edit the configuration
-if you have a Mac or Windows.  
+
+The only prerequisite is libstb.  Although in Windows you will need to
+compile with "gcc", and in OSX "gcc" is best supported.
+
+There is a simple Makefile in this directory currently configured to
+optimise the compiler for a Linux machine.  Edit the configuration if
+you have a Mac or Windows.
 
 By default, multicore version is disabled.  This is because you should 
 get the single core version working and tested first, before

--- a/HCA/doc/hca.1
+++ b/HCA/doc/hca.1
@@ -470,7 +470,7 @@ Can significantly speed up testing or querying sometimes.
 \fB\-r\fP\fItheta\fP
  Second version of the \fB\-r\fP
 option 
-using the string ``phi\&'' as the argument. 
+using the string ``theta\&'' as the argument.
 Restart but now fix the document by topic matrix 
 to the previously estimated values saved at 
 RepStem.theta

--- a/HCA/hca/Makefile
+++ b/HCA/hca/Makefile
@@ -14,7 +14,7 @@ HFILES = data.h hca.h probs.h sample.h stats.h pctl.h diag.h check.h \
 all:    hca
 
 hca:	hca.o $(subst .c,.o,$(CFILES) ) ../util/libhca.a
-	cc  $(CPPFLAGS) $(CFLAGS)  -o hca hca.o $(subst .c,.o,$(CFILES)) $(LDFLAGS)
+	$(CC) $(CPPFLAGS) $(CFLAGS)  -o hca hca.o $(subst .c,.o,$(CFILES)) $(LDFLAGS) $(LIBS)
 
 ../util/libhca.a:
 

--- a/HCA/tca/Makefile
+++ b/HCA/tca/Makefile
@@ -11,7 +11,7 @@ HFILES = data.h tca.h probs.h sample.h stats.h pctl.h change.h
 all:    tca
 
 tca:	tca.o $(subst .c,.o,$(CFILES) ) ../util/libhca.a
-	cc  $(CPPFLAGS) $(CFLAGS)  -o tca tca.o $(subst .c,.o,$(CFILES)) $(LDFLAGS)
+	$(CC)  $(CPPFLAGS) $(CFLAGS)  -o tca tca.o $(subst .c,.o,$(CFILES)) $(LDFLAGS) $(LIBS)
 
 ../util/libhca.a:
 


### PR DESCRIPTION
These changes allow a build to succeed on Ubuntu 14.04 with just "make" when a built libstb is a sibling directory of topic-models.
